### PR TITLE
[IMP] auto_backup: support sftp_public_host_key to add host in known hosts.

### DIFF
--- a/auto_backup/view/db_backup_view.xml
+++ b/auto_backup/view/db_backup_view.xml
@@ -30,6 +30,9 @@
                         <field
                             name="sftp_private_key"
                             placeholder="/home/odoo/.ssh/id_rsa"/>
+                        <field
+                            name="sftp_public_host_key"
+                            placeholder="AAAA..."/>
                         <button
                             name="action_sftp_test_connection"
                             type="object"


### PR DESCRIPTION
The host key verification protects you from man-in-the-middle attacks. Can be generated with command 'ssh-keyscan -p PORT -H HOST/IP' and the right key is immediately after the words 'ssh-rsa'.